### PR TITLE
Initialize Svelte app scaffolding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+dist/
+.vite/
+.DS_Store

--- a/App.svelte
+++ b/App.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+  import Hub from './src/components/Hub.svelte';
+</script>
+
+<main>
+  <Hub />
+</main>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Svelte App</title>
+</head>
+<body>
+  <div id="app"></div>
+  <script type="module" src="/src/main.ts"></script>
+</body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "essay-hausarbeitsarchitekt",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "test": "echo 'No tests specified'"
+  },
+  "devDependencies": {
+    "@sveltejs/vite-plugin-svelte": "^2.0.0",
+    "svelte": "^4.2.0",
+    "typescript": "^5.0.0",
+    "vite": "^5.0.0"
+  }
+}

--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -1,0 +1,6 @@
+// State-Typen
+export interface AppState {
+  // TODO: define application state
+}
+
+export type { AppState };

--- a/src/components/Focus/Analytics.svelte
+++ b/src/components/Focus/Analytics.svelte
@@ -1,0 +1,5 @@
+<script lang="ts">
+  // Analytics component
+</script>
+
+<div>Analytics</div>

--- a/src/components/Focus/Breaks.svelte
+++ b/src/components/Focus/Breaks.svelte
@@ -1,0 +1,5 @@
+<script lang="ts">
+  // Breaks component
+</script>
+
+<div>Breaks</div>

--- a/src/components/Focus/Nudges.svelte
+++ b/src/components/Focus/Nudges.svelte
@@ -1,0 +1,5 @@
+<script lang="ts">
+  // Nudges component
+</script>
+
+<div>Nudges</div>

--- a/src/components/Focus/Pomodoro.svelte
+++ b/src/components/Focus/Pomodoro.svelte
@@ -1,0 +1,5 @@
+<script lang="ts">
+  // Pomodoro component
+</script>
+
+<div>Pomodoro</div>

--- a/src/components/Focus/Ritual.svelte
+++ b/src/components/Focus/Ritual.svelte
@@ -1,0 +1,5 @@
+<script lang="ts">
+  // Ritual component
+</script>
+
+<div>Ritual</div>

--- a/src/components/Hub.svelte
+++ b/src/components/Hub.svelte
@@ -1,0 +1,5 @@
+<script lang="ts">
+  // Hub component
+</script>
+
+<div>Hub</div>

--- a/src/components/Overview.svelte
+++ b/src/components/Overview.svelte
@@ -1,0 +1,5 @@
+<script lang="ts">
+  // Overview component
+</script>
+
+<div>Overview</div>

--- a/src/components/Plan/Arguments.svelte
+++ b/src/components/Plan/Arguments.svelte
@@ -1,0 +1,5 @@
+<script lang="ts">
+  // Arguments component
+</script>
+
+<div>Arguments</div>

--- a/src/components/Plan/Chapters.svelte
+++ b/src/components/Plan/Chapters.svelte
@@ -1,0 +1,5 @@
+<script lang="ts">
+  // Chapters component
+</script>
+
+<div>Chapters</div>

--- a/src/components/Plan/Defs.svelte
+++ b/src/components/Plan/Defs.svelte
@@ -1,0 +1,5 @@
+<script lang="ts">
+  // Definitions component
+</script>
+
+<div>Definitions</div>

--- a/src/components/Plan/Dossier.svelte
+++ b/src/components/Plan/Dossier.svelte
@@ -1,0 +1,5 @@
+<script lang="ts">
+  // Dossier component
+</script>
+
+<div>Dossier</div>

--- a/src/components/Plan/Evidence.svelte
+++ b/src/components/Plan/Evidence.svelte
@@ -1,0 +1,5 @@
+<script lang="ts">
+  // Evidence component
+</script>
+
+<div>Evidence</div>

--- a/src/components/Plan/QA.svelte
+++ b/src/components/Plan/QA.svelte
@@ -1,0 +1,5 @@
+<script lang="ts">
+  // QA component
+</script>
+
+<div>QA</div>

--- a/src/components/Plan/Sessions.svelte
+++ b/src/components/Plan/Sessions.svelte
@@ -1,0 +1,5 @@
+<script lang="ts">
+  // Sessions component
+</script>
+
+<div>Sessions</div>

--- a/src/components/Plan/Zotero.svelte
+++ b/src/components/Plan/Zotero.svelte
@@ -1,0 +1,5 @@
+<script lang="ts">
+  // Zotero component
+</script>
+
+<div>Zotero</div>

--- a/src/components/Weekly.svelte
+++ b/src/components/Weekly.svelte
@@ -1,0 +1,5 @@
+<script lang="ts">
+  // Weekly component
+</script>
+
+<div>Weekly</div>

--- a/src/components/Wrap.svelte
+++ b/src/components/Wrap.svelte
@@ -1,0 +1,5 @@
+<script lang="ts">
+  // Wrap component
+</script>
+
+<div>Wrap</div>

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -1,0 +1,30 @@
+import { writable, type Writable } from 'svelte/store';
+import type { AppState } from '../app';
+
+function persistentWritable<T>(key: string, initial: T): Writable<T> {
+  const stored = typeof localStorage !== 'undefined' ? localStorage.getItem(key) : null;
+  const start: T = stored ? JSON.parse(stored) : initial;
+  const store = writable<T>(start);
+
+  store.subscribe((value) => {
+    if (typeof localStorage !== 'undefined') {
+      localStorage.setItem(key, JSON.stringify(value));
+    }
+    if (typeof indexedDB !== 'undefined') {
+      const request = indexedDB.open('svelte-store', 1);
+      request.onupgradeneeded = () => {
+        request.result.createObjectStore('state');
+      };
+      request.onsuccess = () => {
+        const db = request.result;
+        const tx = db.transaction('state', 'readwrite');
+        tx.objectStore('state').put(value, key);
+        tx.oncomplete = () => db.close();
+      };
+    }
+  });
+
+  return store;
+}
+
+export const appState = persistentWritable<AppState>('app-state', {} as AppState);

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,0 +1,7 @@
+import App from '../App.svelte';
+
+const app = new App({
+  target: document.getElementById('app') as HTMLElement,
+});
+
+export default app;

--- a/src/utils/csv.ts
+++ b/src/utils/csv.ts
@@ -1,0 +1,4 @@
+// CSV utilities placeholder
+export function toCSV() {
+  // TODO: implement CSV generation
+}

--- a/src/utils/fileSystem.ts
+++ b/src/utils/fileSystem.ts
@@ -1,0 +1,4 @@
+// File system utilities placeholder
+export function saveFile() {
+  // TODO: implement file saving
+}

--- a/src/utils/fsmTimer.ts
+++ b/src/utils/fsmTimer.ts
@@ -1,0 +1,4 @@
+// Finite state machine timer placeholder
+export function fsmTimer() {
+  // TODO: implement timer
+}

--- a/src/utils/ics.ts
+++ b/src/utils/ics.ts
@@ -1,0 +1,4 @@
+// ICS file utilities placeholder
+export function createICS() {
+  // TODO: implement ICS generation
+}

--- a/src/utils/xlsXml.ts
+++ b/src/utils/xlsXml.ts
@@ -1,0 +1,4 @@
+// XLS XML utilities placeholder
+export function toXlsXml() {
+  // TODO: implement XLS XML generation
+}

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -1,0 +1,5 @@
+import { vitePreprocess } from '@sveltejs/vite-plugin-svelte';
+
+export default {
+  preprocess: vitePreprocess(),
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "module": "ESNext",
+    "target": "ESNext",
+    "moduleResolution": "Node",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src/**/*", "App.svelte"]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite';
+import { svelte } from '@sveltejs/vite-plugin-svelte';
+
+export default defineConfig({
+  plugins: [svelte()]
+});


### PR DESCRIPTION
## Summary
- scaffold Svelte application using Vite configuration and TS support
- add persistent writable store backed by localStorage and IndexedDB
- create placeholder components for planning, focus, and utilities

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68acc96dc188832aa22b9aa39ebdbda0